### PR TITLE
Refine marketing contact page

### DIFF
--- a/docs/marketing-pages.md
+++ b/docs/marketing-pages.md
@@ -1,0 +1,21 @@
+# Suggested Marketing Pages
+
+This document lists potential marketing pages for Badget. Each page should follow the existing marketing layout located at `src/app/(marketing)/layout.tsx` and use the global colors defined in `src/app/globals.css`.
+
+1. **About Us / Mission** – Overview of the company and team.
+2. **Blog / Resources** – Articles on personal finance tips, product updates and announcements.
+3. **Security & Compliance** – Explain data protection, SOC2/HIPAA/GDPR.
+4. **Integrations** – Showcase supported banks or third‑party services.
+5. **Documentation / Getting Started** – Step‑by‑step guide on setting up accounts and using features.
+6. **Pricing** – A standalone page outlining subscription options.
+7. **Case Studies / Testimonials** – Success stories from users or families.
+8. **Press / Media Kit** – Logos, screenshots and contact info for journalists.
+9. **Careers** – Job openings and culture description.
+10. **Community** – Links to Discord, GitHub and other social channels for engagement.
+11. **Changelog / Roadmap** – Highlight ongoing development and upcoming features.
+12. **Contact / Support** – Simple form and direct links to email or social support.
+13. **Legal** – Separate "Privacy Policy" and "Terms of Service" pages.
+14. **Affiliate or Referral Program** – Explain how users can earn rewards by sharing the app.
+15. **Accessibility Statement** – Demonstrate commitment to accessible design.
+
+Use these ideas as a starting point when expanding the marketing site.

--- a/src/app/(marketing)/community/page.tsx
+++ b/src/app/(marketing)/community/page.tsx
@@ -1,0 +1,28 @@
+import { siteConfig } from "@/lib/config";
+import Link from "next/link";
+
+export default function CommunityPage() {
+  const { discord, github, twitter, instagram } = siteConfig.links;
+  return (
+    <main className="flex flex-col items-center justify-start min-h-[80vh] w-full py-20 px-5 space-y-6">
+      <h1 className="text-3xl md:text-4xl font-medium tracking-tight">Join the Badget Community</h1>
+      <p className="text-muted-foreground text-center max-w-md">
+        Connect with us and other users through our social channels.
+      </p>
+      <div className="flex flex-wrap items-center justify-center gap-4">
+        <Link href={discord} target="_blank" className="underline text-primary">
+          Discord
+        </Link>
+        <Link href={github} target="_blank" className="underline text-primary">
+          GitHub
+        </Link>
+        <Link href={twitter} target="_blank" className="underline text-primary">
+          X
+        </Link>
+        <Link href={instagram} target="_blank" className="underline text-primary">
+          Instagram
+        </Link>
+      </div>
+    </main>
+  );
+}

--- a/src/app/(marketing)/contact/page.tsx
+++ b/src/app/(marketing)/contact/page.tsx
@@ -1,0 +1,42 @@
+import { siteConfig } from "@/lib/config";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Button } from "@/components/ui/button";
+
+export default function ContactPage() {
+  return (
+    <main className="flex flex-col items-center justify-start min-h-[80vh] w-full py-20 px-5">
+      <div className="border-x mx-5 md:mx-10 relative w-full max-w-3xl">
+        <div className="absolute top-0 -left-4 md:-left-14 h-full w-4 md:w-14 text-primary/5 bg-[size:10px_10px] [background-image:repeating-linear-gradient(315deg,currentColor_0_1px,#0000_0_50%)]"></div>
+        <div className="absolute top-0 -right-4 md:-right-14 h-full w-4 md:w-14 text-primary/5 bg-[size:10px_10px] [background-image:repeating-linear-gradient(315deg,currentColor_0_1px,#0000_0_50%)]"></div>
+        <div className="px-6 md:px-10 py-10 flex flex-col items-center gap-8">
+          <div className="text-center space-y-2">
+            <h1 className="text-3xl md:text-4xl font-medium tracking-tight">Contact Us</h1>
+            <p className="text-muted-foreground">Have questions or need help? Send us a message.</p>
+          </div>
+          <form className="grid gap-4 w-full max-w-md mx-auto">
+            <div className="grid gap-2">
+              <Label htmlFor="name">Name</Label>
+              <Input id="name" type="text" placeholder="Your name" />
+            </div>
+            <div className="grid gap-2">
+              <Label htmlFor="email">Email</Label>
+              <Input id="email" type="email" placeholder="you@example.com" required />
+            </div>
+            <div className="grid gap-2">
+              <Label htmlFor="message">Message</Label>
+              <textarea id="message" className="min-h-[120px] p-2 border rounded-md" placeholder="How can we help?" />
+            </div>
+            <Button type="submit" className="w-full">Send Message</Button>
+          </form>
+          <p className="text-muted-foreground text-sm text-center">
+            Or email us directly at{' '}
+            <a href={`mailto:${siteConfig.links.email}`} className="underline">
+              {siteConfig.links.email}
+            </a>
+          </p>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/src/app/(marketing)/legal/privacy/page.tsx
+++ b/src/app/(marketing)/legal/privacy/page.tsx
@@ -1,0 +1,12 @@
+import { siteConfig } from "@/lib/config";
+
+export default function PrivacyPolicyPage() {
+  return (
+    <main className="flex flex-col items-center justify-start min-h-[80vh] w-full py-20 px-5 space-y-6">
+      <h1 className="text-3xl md:text-4xl font-medium tracking-tight">Privacy Policy</h1>
+      <p className="text-muted-foreground max-w-2xl text-center">
+        This is a placeholder privacy policy for {siteConfig.name}. Update this page with the actual policy before launch.
+      </p>
+    </main>
+  );
+}

--- a/src/app/(marketing)/legal/terms/page.tsx
+++ b/src/app/(marketing)/legal/terms/page.tsx
@@ -1,0 +1,10 @@
+export default function TermsOfServicePage() {
+  return (
+    <main className="flex flex-col items-center justify-start min-h-[80vh] w-full py-20 px-5 space-y-6">
+      <h1 className="text-3xl md:text-4xl font-medium tracking-tight">Terms of Service</h1>
+      <p className="text-muted-foreground max-w-2xl text-center">
+        These terms of service are a placeholder and should be replaced with your official terms.
+      </p>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- keep suggested marketing pages doc
- refine contact page using same bordered style as other sections

## Testing
- `pnpm lint` *(fails: next not found since dependencies missing)*
- `pnpm install` *(fails: cannot download prisma binaries)*

------
https://chatgpt.com/codex/tasks/task_e_68567abb9c788330b27c05ee0b8d94ff