### PR TITLE
Add asset news support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,3 +11,7 @@ GOOGLE_CLIENT_SECRET="your_google_client_secret_here"
 
 # Application URL
 NEXT_PUBLIC_APP_URL="your_app_url_here"
+
+# News API configuration
+NEWS_API_URL="https://api.marketaux.com/v1/news/all"
+NEWS_API_TOKEN="your_marketaux_api_token"

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -464,6 +464,28 @@ model Goal {
   @@map("goals")
 }
 
+enum AssetType {
+  STOCK
+  CRYPTO
+  OTHER
+}
+
+model InvestmentAsset {
+  id        String    @id @default(cuid())
+  name      String
+  ticker    String
+  assetType AssetType
+  quantity  Decimal   @default(0) @db.Decimal(12, 2)
+  createdAt DateTime  @default(now())
+  updatedAt DateTime  @updatedAt
+
+  familyId String
+  family   Family @relation(fields: [familyId], references: [id], onDelete: Cascade)
+
+  @@index([familyId])
+  @@map("investment_assets")
+}
+
 // ---------- INDEXES AND CONSTRAINTS ----------
 
 // Performance indexes

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -241,6 +241,7 @@ model Family {
   Transaction      Transaction[]
   Budget           Budget[]
   Goal             Goal[]
+  InvestmentAsset  InvestmentAsset[]
 
   @@map("families")
 }

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -3,6 +3,7 @@ import {
   AccountType,
   TransactionType,
   TransactionStatus,
+  AssetType,
   GoalType,
   BudgetPeriod,
   FamilyRole,
@@ -486,7 +487,7 @@ async function main() {
         date: new Date(
           monthDate.getFullYear(),
           monthDate.getMonth(),
-          Math.floor(Math.random() * 28) + 1
+          Math.floor(Math.random() * 28) + 1,
         ),
         description: "Freelance Payment",
         merchant: "Client XYZ",
@@ -561,7 +562,7 @@ async function main() {
           date: new Date(
             monthDate.getFullYear(),
             monthDate.getMonth(),
-            Math.floor(Math.random() * 28) + 1
+            Math.floor(Math.random() * 28) + 1,
           ),
           description: `${expense.desc} ${i + 1}`,
           merchant: `${expense.desc} Store`,
@@ -587,7 +588,7 @@ async function main() {
         date: new Date(
           monthDate.getFullYear(),
           monthDate.getMonth(),
-          Math.floor(Math.random() * 28) + 1
+          Math.floor(Math.random() * 28) + 1,
         ),
         description: `Random ${randomExpense.desc}`,
         merchant: "Various",
@@ -616,8 +617,29 @@ async function main() {
   }
 
   console.log(
-    `✅ Created ${monthlyData.length} monthly transactions spanning 8 months`
+    `✅ Created ${monthlyData.length} monthly transactions spanning 8 months`,
   );
+
+  // Create sample investment assets
+  await prisma.investmentAsset.createMany({
+    data: [
+      {
+        name: "Apple Inc.",
+        ticker: "AAPL",
+        assetType: AssetType.STOCK,
+        quantity: 10,
+        familyId: family.id,
+      },
+      {
+        name: "Bitcoin",
+        ticker: "BTC",
+        assetType: AssetType.CRYPTO,
+        quantity: 0.5,
+        familyId: family.id,
+      },
+    ],
+  });
+  console.log("✅ Created sample investment assets");
 
   console.log("🎉 Database seeded successfully!");
 }

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -487,7 +487,7 @@ async function main() {
         date: new Date(
           monthDate.getFullYear(),
           monthDate.getMonth(),
-          Math.floor(Math.random() * 28) + 1,
+          Math.floor(Math.random() * 28) + 1
         ),
         description: "Freelance Payment",
         merchant: "Client XYZ",
@@ -562,7 +562,7 @@ async function main() {
           date: new Date(
             monthDate.getFullYear(),
             monthDate.getMonth(),
-            Math.floor(Math.random() * 28) + 1,
+            Math.floor(Math.random() * 28) + 1
           ),
           description: `${expense.desc} ${i + 1}`,
           merchant: `${expense.desc} Store`,
@@ -588,7 +588,7 @@ async function main() {
         date: new Date(
           monthDate.getFullYear(),
           monthDate.getMonth(),
-          Math.floor(Math.random() * 28) + 1,
+          Math.floor(Math.random() * 28) + 1
         ),
         description: `Random ${randomExpense.desc}`,
         merchant: "Various",
@@ -617,11 +617,13 @@ async function main() {
   }
 
   console.log(
-    `✅ Created ${monthlyData.length} monthly transactions spanning 8 months`,
+    `✅ Created ${monthlyData.length} monthly transactions spanning 8 months`
   );
 
   // Create sample investment assets
-  await prisma.investmentAsset.createMany({
+  console.log("🔍 About to create investment assets with familyId:", family.id);
+
+  const createdAssets = await prisma.investmentAsset.createMany({
     data: [
       {
         name: "Apple Inc.",
@@ -639,7 +641,27 @@ async function main() {
       },
     ],
   });
-  console.log("✅ Created sample investment assets");
+
+  console.log("✅ Created sample investment assets:", createdAssets.count);
+
+  // Verify the assets were created by querying them back
+  const verifyAssets = await prisma.investmentAsset.findMany({
+    where: { familyId: family.id },
+    select: {
+      id: true,
+      name: true,
+      ticker: true,
+      assetType: true,
+      quantity: true,
+      familyId: true,
+    },
+  });
+
+  console.log(
+    "🔍 Verification - Found assets in database:",
+    verifyAssets.length
+  );
+  console.log("📊 Asset details:", verifyAssets);
 
   console.log("🎉 Database seeded successfully!");
 }

--- a/src/actions/asset-actions.ts
+++ b/src/actions/asset-actions.ts
@@ -9,15 +9,24 @@ function getPrismaClient() {
 
 async function getActiveFamilyId(): Promise<string | null> {
   const appUser = await getCurrentAppUser();
+  console.log(
+    "🔍 getActiveFamilyId - appUser:",
+    appUser ? "found" : "not found"
+  );
   if (!appUser || !appUser.familyMemberships.length) {
+    console.log("❌ No appUser or family memberships found");
     return null;
   }
-  return appUser.familyMemberships[0].familyId;
+  const familyId = appUser.familyMemberships[0].familyId;
+  console.log("✅ Active family ID:", familyId);
+  return familyId;
 }
 
 export async function getInvestmentAssets() {
+  console.log("🔍 getInvestmentAssets - Starting...");
   const familyId = await getActiveFamilyId();
   if (!familyId) {
+    console.log("❌ No family ID found");
     return [];
   }
 
@@ -35,12 +44,15 @@ export async function getInvestmentAssets() {
       orderBy: { name: "asc" },
     });
 
+    console.log("✅ Found assets:", assets.length);
+    console.log("📊 Assets details:", assets);
+
     return assets.map((asset) => ({
       ...asset,
       quantity: Number(asset.quantity),
     }));
   } catch (error) {
-    console.error("Error fetching investment assets:", error);
+    console.error("❌ Error fetching investment assets:", error);
     return [];
   } finally {
     await prisma.$disconnect();
@@ -67,42 +79,84 @@ interface RawArticle {
 }
 
 export async function getAssetNews(
-  tickers: string[],
+  tickers: string[]
 ): Promise<AssetNewsItem[]> {
-  if (!tickers.length) return [];
+  console.log("🔍 getAssetNews - Starting with tickers:", tickers);
+
+  if (!tickers.length) {
+    console.log("❌ No tickers provided");
+    return [];
+  }
 
   const apiToken = process.env.NEWS_API_TOKEN;
   const baseUrl =
     process.env.NEWS_API_URL || "https://api.marketaux.com/v1/news/all";
+
+  console.log("🔧 API Config:", {
+    hasApiToken: !!apiToken,
+    baseUrl,
+    tickersCount: tickers.length,
+  });
 
   try {
     const url =
       `${baseUrl}?symbols=${encodeURIComponent(tickers.join(","))}` +
       (apiToken ? `&api_token=${apiToken}` : "");
 
+    console.log(
+      "🌐 Fetching from URL:",
+      url.replace(apiToken || "", "[REDACTED]")
+    );
+
     const res = await fetch(url, { next: { revalidate: 300 } });
+
+    console.log("📡 API Response status:", res.status);
+
     if (!res.ok) {
+      console.error("❌ News API error:", res.status, res.statusText);
       throw new Error(`News API error: ${res.status}`);
     }
 
     const json = await res.json();
+    console.log("📄 Raw API response keys:", Object.keys(json));
+    console.log(
+      "📊 Raw articles count:",
+      (json.data ?? json.results ?? []).length
+    );
+
     const articles = (json.data ?? json.results ?? []) as RawArticle[];
 
-    return articles.map((item) => ({
+    const formattedNews = articles.map((item) => ({
       id: item.id ?? item.uuid ?? item.url,
       title: item.title,
       url: item.url,
       source: item.source ?? item.source_name ?? "",
       publishedAt: item.published_at ?? item.date ?? "",
     }));
+
+    console.log("✅ Formatted news items:", formattedNews.length);
+    if (formattedNews.length > 0) {
+      console.log("📰 First news item:", formattedNews[0]);
+    }
+
+    return formattedNews;
   } catch (error) {
-    console.error("Error fetching asset news:", error);
+    console.error("❌ Error fetching asset news:", error);
     return [];
   }
 }
 
 export async function getNewsForUserAssets() {
+  console.log("🔍 getNewsForUserAssets - Starting...");
+
   const assets = await getInvestmentAssets();
+  console.log("📊 Retrieved assets:", assets.length);
+
   const tickers = assets.map((a) => a.ticker).filter(Boolean);
-  return await getAssetNews(tickers);
+  console.log("🎯 Extracted tickers:", tickers);
+
+  const news = await getAssetNews(tickers);
+  console.log("📰 Final news count:", news.length);
+
+  return news;
 }

--- a/src/actions/asset-actions.ts
+++ b/src/actions/asset-actions.ts
@@ -1,0 +1,108 @@
+"use server";
+
+import { PrismaClient } from "@/generated/prisma";
+import { getCurrentAppUser } from "./user-actions";
+
+function getPrismaClient() {
+  return new PrismaClient();
+}
+
+async function getActiveFamilyId(): Promise<string | null> {
+  const appUser = await getCurrentAppUser();
+  if (!appUser || !appUser.familyMemberships.length) {
+    return null;
+  }
+  return appUser.familyMemberships[0].familyId;
+}
+
+export async function getInvestmentAssets() {
+  const familyId = await getActiveFamilyId();
+  if (!familyId) {
+    return [];
+  }
+
+  const prisma = getPrismaClient();
+  try {
+    const assets = await prisma.investmentAsset.findMany({
+      where: { familyId },
+      select: {
+        id: true,
+        name: true,
+        ticker: true,
+        assetType: true,
+        quantity: true,
+      },
+      orderBy: { name: "asc" },
+    });
+
+    return assets.map((asset) => ({
+      ...asset,
+      quantity: Number(asset.quantity),
+    }));
+  } catch (error) {
+    console.error("Error fetching investment assets:", error);
+    return [];
+  } finally {
+    await prisma.$disconnect();
+  }
+}
+
+export interface AssetNewsItem {
+  id: string;
+  title: string;
+  url: string;
+  source: string;
+  publishedAt: string;
+}
+
+interface RawArticle {
+  id?: string;
+  uuid?: string;
+  url: string;
+  title: string;
+  source?: string;
+  source_name?: string;
+  published_at?: string;
+  date?: string;
+}
+
+export async function getAssetNews(
+  tickers: string[],
+): Promise<AssetNewsItem[]> {
+  if (!tickers.length) return [];
+
+  const apiToken = process.env.NEWS_API_TOKEN;
+  const baseUrl =
+    process.env.NEWS_API_URL || "https://api.marketaux.com/v1/news/all";
+
+  try {
+    const url =
+      `${baseUrl}?symbols=${encodeURIComponent(tickers.join(","))}` +
+      (apiToken ? `&api_token=${apiToken}` : "");
+
+    const res = await fetch(url, { next: { revalidate: 300 } });
+    if (!res.ok) {
+      throw new Error(`News API error: ${res.status}`);
+    }
+
+    const json = await res.json();
+    const articles = (json.data ?? json.results ?? []) as RawArticle[];
+
+    return articles.map((item) => ({
+      id: item.id ?? item.uuid ?? item.url,
+      title: item.title,
+      url: item.url,
+      source: item.source ?? item.source_name ?? "",
+      publishedAt: item.published_at ?? item.date ?? "",
+    }));
+  } catch (error) {
+    console.error("Error fetching asset news:", error);
+    return [];
+  }
+}
+
+export async function getNewsForUserAssets() {
+  const assets = await getInvestmentAssets();
+  const tickers = assets.map((a) => a.ticker).filter(Boolean);
+  return await getAssetNews(tickers);
+}

--- a/src/actions/dashboard-actions.ts
+++ b/src/actions/dashboard-actions.ts
@@ -59,6 +59,7 @@ import type {
   GoalType,
   BudgetPeriod,
 } from "@/generated/prisma";
+import { AssetType } from "@/generated/prisma";
 
 // Prisma client instantiation per request (best practice)
 function getPrismaClient() {
@@ -938,6 +939,30 @@ export async function seedUserData(resetFirst: boolean = false) {
           data: goal,
         });
       }
+
+      // Create sample investment assets
+      console.log("🔍 Creating investment assets for familyId:", family.id);
+
+      await tx.investmentAsset.createMany({
+        data: [
+          {
+            name: "Apple Inc.",
+            ticker: "AAPL",
+            assetType: AssetType.STOCK,
+            quantity: 10,
+            familyId: family.id,
+          },
+          {
+            name: "Bitcoin",
+            ticker: "BTC",
+            assetType: AssetType.CRYPTO,
+            quantity: 0.5,
+            familyId: family.id,
+          },
+        ],
+      });
+
+      console.log("✅ Created investment assets successfully");
 
       return { success: true, familyId: family.id };
     });

--- a/src/components/dashboard/async-components.tsx
+++ b/src/components/dashboard/async-components.tsx
@@ -10,6 +10,7 @@ import {
   getFinancialGoals,
   getTransactions,
 } from "@/actions/dashboard-actions";
+import { getNewsForUserAssets } from "@/actions/asset-actions";
 import {
   HeaderSkeleton,
   MetricsSkeleton,
@@ -30,8 +31,11 @@ async function AsyncAnalyticsSection() {
 }
 
 async function AsyncInsightsSection() {
-  const goals = await getFinancialGoals();
-  return <InsightsSection goals={goals} />;
+  const [goals, assetNews] = await Promise.all([
+    getFinancialGoals(),
+    getNewsForUserAssets(),
+  ]);
+  return <InsightsSection goals={goals} assetNews={assetNews} />;
 }
 
 async function AsyncTransactionSection() {

--- a/src/components/dashboard/insights-section.tsx
+++ b/src/components/dashboard/insights-section.tsx
@@ -46,13 +46,6 @@ function formatTimeAgo(dateString: string) {
 }
 
 export function InsightsSection({ goals, assetNews }: InsightsSectionProps) {
-  // Debug logging
-  console.log("🎨 InsightsSection received:", {
-    goalsCount: goals.length,
-    assetNewsCount: assetNews.length,
-    assetNews: assetNews,
-  });
-
   // Find the emergency fund goal for display
   const emergencyFundGoal = goals.find(
     (goal) => goal.type === "EMERGENCY_FUND" && goal.isActive
@@ -72,34 +65,46 @@ export function InsightsSection({ goals, assetNews }: InsightsSectionProps) {
       <div className="p-6 space-y-4">
         <div className="space-y-3">
           {/* Display real asset news if available */}
-          {recentNews.map((newsItem) => (
-            <div key={newsItem.id} className="p-3 border rounded-lg">
-              <h4 className="font-medium text-sm mb-1">
-                <a
-                  href={newsItem.url}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="hover:underline"
-                >
-                  {newsItem.title}
-                </a>
-              </h4>
-              <p className="text-xs text-muted-foreground mb-2">
-                Related to your investment portfolio
-              </p>
-              <div className="flex items-center gap-2 text-xs">
-                <Badge
-                  variant="secondary"
-                  className="bg-emerald-100 text-emerald-700"
-                >
-                  📈 {newsItem.source}
-                </Badge>
-                <span className="text-muted-foreground">
-                  {formatTimeAgo(newsItem.publishedAt)}
-                </span>
+          {recentNews.map((newsItem) => {
+            const isFallback = newsItem.id.startsWith("fallback-");
+            return (
+              <div key={newsItem.id} className="p-3 border rounded-lg">
+                <h4 className="font-medium text-sm mb-1">
+                  {newsItem.url === "#" ? (
+                    <span>{newsItem.title}</span>
+                  ) : (
+                    <a
+                      href={newsItem.url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="hover:underline"
+                    >
+                      {newsItem.title}
+                    </a>
+                  )}
+                </h4>
+                <p className="text-xs text-muted-foreground mb-2">
+                  Related to your investment portfolio
+                  {isFallback && " • Sample news (API unavailable)"}
+                </p>
+                <div className="flex items-center gap-2 text-xs">
+                  <Badge
+                    variant="secondary"
+                    className={
+                      isFallback
+                        ? "bg-gray-100 text-gray-700"
+                        : "bg-emerald-100 text-emerald-700"
+                    }
+                  >
+                    {isFallback ? "📰" : "📈"} {newsItem.source}
+                  </Badge>
+                  <span className="text-muted-foreground">
+                    {formatTimeAgo(newsItem.publishedAt)}
+                  </span>
+                </div>
               </div>
-            </div>
-          ))}
+            );
+          })}
 
           {/* Fallback content if no news available */}
           {recentNews.length === 0 && (

--- a/src/components/dashboard/insights-section.tsx
+++ b/src/components/dashboard/insights-section.tsx
@@ -11,8 +11,17 @@ type FinancialGoal = {
   isActive: boolean;
 };
 
+type AssetNewsItem = {
+  id: string;
+  title: string;
+  url: string;
+  source: string;
+  publishedAt: string;
+};
+
 interface InsightsSectionProps {
   goals: FinancialGoal[];
+  assetNews: AssetNewsItem[];
 }
 
 function formatCurrency(amount: number) {
@@ -26,11 +35,31 @@ function calculateProgress(current: number, target: number) {
   return Math.min((current / target) * 100, 100);
 }
 
-export function InsightsSection({ goals }: InsightsSectionProps) {
+function formatTimeAgo(dateString: string) {
+  if (!dateString) return "recently";
+  try {
+    const date = new Date(dateString);
+    return formatDistanceToNow(date, { addSuffix: true });
+  } catch {
+    return "recently";
+  }
+}
+
+export function InsightsSection({ goals, assetNews }: InsightsSectionProps) {
+  // Debug logging
+  console.log("🎨 InsightsSection received:", {
+    goalsCount: goals.length,
+    assetNewsCount: assetNews.length,
+    assetNews: assetNews,
+  });
+
   // Find the emergency fund goal for display
   const emergencyFundGoal = goals.find(
     (goal) => goal.type === "EMERGENCY_FUND" && goal.isActive
   );
+
+  // Get the latest asset news items (limit to 2 most recent)
+  const recentNews = assetNews.slice(0, 2);
 
   return (
     <div className="border rounded-lg">
@@ -42,27 +71,55 @@ export function InsightsSection({ goals }: InsightsSectionProps) {
       </div>
       <div className="p-6 space-y-4">
         <div className="space-y-3">
-          <div className="p-3 border rounded-lg">
-            <h4 className="font-medium text-sm mb-1">
-              Tech Stocks Rally: AAPL & MSFT Lead Gains
-            </h4>
-            <p className="text-xs text-muted-foreground mb-2">
-              Your portfolio gained 2.3% this week driven by tech sector growth
-            </p>
-            <div className="flex items-center gap-2 text-xs">
-              <Badge
-                variant="secondary"
-                className="bg-emerald-100 text-emerald-700"
-              >
-                📈 Market Update
-              </Badge>
-              <span className="text-muted-foreground">
-                {formatDistanceToNow(subHours(new Date(), 2), {
-                  addSuffix: true,
-                })}
-              </span>
+          {/* Display real asset news if available */}
+          {recentNews.map((newsItem) => (
+            <div key={newsItem.id} className="p-3 border rounded-lg">
+              <h4 className="font-medium text-sm mb-1">
+                <a
+                  href={newsItem.url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="hover:underline"
+                >
+                  {newsItem.title}
+                </a>
+              </h4>
+              <p className="text-xs text-muted-foreground mb-2">
+                Related to your investment portfolio
+              </p>
+              <div className="flex items-center gap-2 text-xs">
+                <Badge
+                  variant="secondary"
+                  className="bg-emerald-100 text-emerald-700"
+                >
+                  📈 {newsItem.source}
+                </Badge>
+                <span className="text-muted-foreground">
+                  {formatTimeAgo(newsItem.publishedAt)}
+                </span>
+              </div>
             </div>
-          </div>
+          ))}
+
+          {/* Fallback content if no news available */}
+          {recentNews.length === 0 && (
+            <div className="p-3 border rounded-lg">
+              <h4 className="font-medium text-sm mb-1">
+                Market News Unavailable
+              </h4>
+              <p className="text-xs text-muted-foreground mb-2">
+                Add some investment assets to see personalized market updates
+              </p>
+              <div className="flex items-center gap-2 text-xs">
+                <Badge
+                  variant="secondary"
+                  className="bg-gray-100 text-gray-700"
+                >
+                  💡 Tip
+                </Badge>
+              </div>
+            </div>
+          )}
 
           <div className="p-3 border rounded-lg">
             <h4 className="font-medium text-sm mb-1">


### PR DESCRIPTION
## Summary
- add example NEWS_API settings
- create `InvestmentAsset` model for tickers
- seed a few assets
- implement asset/news actions

## Testing
- `pnpm lint`
- `pnpm db:generate` *(fails: Command failed with exit code 1)*

------
https://chatgpt.com/codex/tasks/task_e_6857ad2992d883308f67c32abca1c79c