### PR TITLE
Add financial accounts dashboard page

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "@radix-ui/react-tooltip": "^1.2.7",
     "@tabler/icons-react": "^3.34.0",
     "@tanstack/react-table": "^8.21.3",
+    "@tremor/react": "^3.18.7",
     "better-auth": "^1.2.9",
     "canvas-confetti": "^1.9.3",
     "class-variance-authority": "^0.7.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -119,6 +119,9 @@ dependencies:
   '@tanstack/react-table':
     specifier: ^8.21.3
     version: 8.21.3(react-dom@19.1.0)(react@19.1.0)
+  '@tremor/react':
+    specifier: ^3.18.7
+    version: 3.18.7(react-dom@19.1.0)(react@19.1.0)
   better-auth:
     specifier: ^1.2.9
     version: 1.2.9
@@ -821,6 +824,17 @@ packages:
       '@floating-ui/utils': 0.2.9
     dev: false
 
+  /@floating-ui/react-dom@1.3.0(react-dom@19.1.0)(react@19.1.0):
+    resolution: {integrity: sha512-htwHm67Ji5E/pROEAr7f8IKFShuiCKHwUC/UY4vC3I5jiSvGFAYnSYiZO5MlGmads+QqvUkR9ANHEguGrDv72g==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+    dependencies:
+      '@floating-ui/dom': 1.7.1
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    dev: false
+
   /@floating-ui/react-dom@2.1.3(react-dom@19.1.0)(react@19.1.0):
     resolution: {integrity: sha512-huMBfiU9UnQ2oBwIhgzyIiSpVgvlDstU8CX0AF+wS+KzmYMs0J2a3GwuFHV1Lz+jlrQGeC1fF+Nv0QoumyV0bA==}
     peerDependencies:
@@ -832,8 +846,49 @@ packages:
       react-dom: 19.1.0(react@19.1.0)
     dev: false
 
+  /@floating-ui/react@0.19.2(react-dom@19.1.0)(react@19.1.0):
+    resolution: {integrity: sha512-JyNk4A0Ezirq8FlXECvRtQOX/iBe5Ize0W/pLkrZjfHW9GUV7Xnq6zm6fyZuQzaHHqEnVizmvlA96e1/CkZv+w==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+    dependencies:
+      '@floating-ui/react-dom': 1.3.0(react-dom@19.1.0)(react@19.1.0)
+      aria-hidden: 1.2.6
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+      tabbable: 6.2.0
+    dev: false
+
+  /@floating-ui/react@0.26.28(react-dom@19.1.0)(react@19.1.0):
+    resolution: {integrity: sha512-yORQuuAtVpiRjpMhdc0wJj06b9JFjrYF4qp96j++v2NBpbi6SEGF7donUJ3TMieerQ6qVkAv1tgr7L4r5roTqw==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+    dependencies:
+      '@floating-ui/react-dom': 2.1.3(react-dom@19.1.0)(react@19.1.0)
+      '@floating-ui/utils': 0.2.9
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+      tabbable: 6.2.0
+    dev: false
+
   /@floating-ui/utils@0.2.9:
     resolution: {integrity: sha512-MDWhGtE+eHw5JW7lq4qhc5yRLS11ERl1c7Z6Xd0a58DozHES6EnNNwUWbMiG4J9Cgj053Bhk8zvlhFYKVhULwg==}
+    dev: false
+
+  /@headlessui/react@2.2.0(react-dom@19.1.0)(react@19.1.0):
+    resolution: {integrity: sha512-RzCEg+LXsuI7mHiSomsu/gBJSjpupm6A1qIZ5sWjd7JhARNlMiSA4kKfJpCKwU9tE+zMRterhhrP74PvfJrpXQ==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      react: ^18 || ^19 || ^19.0.0-rc
+      react-dom: ^18 || ^19 || ^19.0.0-rc
+    dependencies:
+      '@floating-ui/react': 0.26.28(react-dom@19.1.0)(react@19.1.0)
+      '@react-aria/focus': 3.20.5(react-dom@19.1.0)(react@19.1.0)
+      '@react-aria/interactions': 3.25.3(react-dom@19.1.0)(react@19.1.0)
+      '@tanstack/react-virtual': 3.13.11(react-dom@19.1.0)(react@19.1.0)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
     dev: false
 
   /@hexagon/base64@1.1.28:
@@ -2541,6 +2596,62 @@ packages:
     resolution: {integrity: sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==}
     dev: false
 
+  /@react-aria/focus@3.20.5(react-dom@19.1.0)(react@19.1.0):
+    resolution: {integrity: sha512-JpFtXmWQ0Oca7FcvkqgjSyo6xEP7v3oQOLUId6o0xTvm4AD5W0mU2r3lYrbhsJ+XxdUUX4AVR5473sZZ85kU4A==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    dependencies:
+      '@react-aria/interactions': 3.25.3(react-dom@19.1.0)(react@19.1.0)
+      '@react-aria/utils': 3.29.1(react-dom@19.1.0)(react@19.1.0)
+      '@react-types/shared': 3.30.0(react@19.1.0)
+      '@swc/helpers': 0.5.15
+      clsx: 2.1.1
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    dev: false
+
+  /@react-aria/interactions@3.25.3(react-dom@19.1.0)(react@19.1.0):
+    resolution: {integrity: sha512-J1bhlrNtjPS/fe5uJQ+0c7/jiXniwa4RQlP+Emjfc/iuqpW2RhbF9ou5vROcLzWIyaW8tVMZ468J68rAs/aZ5A==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    dependencies:
+      '@react-aria/ssr': 3.9.9(react@19.1.0)
+      '@react-aria/utils': 3.29.1(react-dom@19.1.0)(react@19.1.0)
+      '@react-stately/flags': 3.1.2
+      '@react-types/shared': 3.30.0(react@19.1.0)
+      '@swc/helpers': 0.5.15
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    dev: false
+
+  /@react-aria/ssr@3.9.9(react@19.1.0):
+    resolution: {integrity: sha512-2P5thfjfPy/np18e5wD4WPt8ydNXhij1jwA8oehxZTFqlgVMGXzcWKxTb4RtJrLFsqPO7RUQTiY8QJk0M4Vy2g==}
+    engines: {node: '>= 12'}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    dependencies:
+      '@swc/helpers': 0.5.15
+      react: 19.1.0
+    dev: false
+
+  /@react-aria/utils@3.29.1(react-dom@19.1.0)(react@19.1.0):
+    resolution: {integrity: sha512-yXMFVJ73rbQ/yYE/49n5Uidjw7kh192WNN9PNQGV0Xoc7EJUlSOxqhnpHmYTyO0EotJ8fdM1fMH8durHjUSI8g==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    dependencies:
+      '@react-aria/ssr': 3.9.9(react@19.1.0)
+      '@react-stately/flags': 3.1.2
+      '@react-stately/utils': 3.10.7(react@19.1.0)
+      '@react-types/shared': 3.30.0(react@19.1.0)
+      '@swc/helpers': 0.5.15
+      clsx: 2.1.1
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    dev: false
+
   /@react-email/render@1.1.2(react-dom@19.1.0)(react@19.1.0):
     resolution: {integrity: sha512-RnRehYN3v9gVlNMehHPHhyp2RQo7+pSkHDtXPvg3s0GbzM9SQMW4Qrf8GRNvtpLC4gsI+Wt0VatNRUFqjvevbw==}
     engines: {node: '>=18.0.0'}
@@ -2553,6 +2664,29 @@ packages:
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
       react-promise-suspense: 0.3.4
+    dev: false
+
+  /@react-stately/flags@3.1.2:
+    resolution: {integrity: sha512-2HjFcZx1MyQXoPqcBGALwWWmgFVUk2TuKVIQxCbRq7fPyWXIl6VHcakCLurdtYC2Iks7zizvz0Idv48MQ38DWg==}
+    dependencies:
+      '@swc/helpers': 0.5.15
+    dev: false
+
+  /@react-stately/utils@3.10.7(react@19.1.0):
+    resolution: {integrity: sha512-cWvjGAocvy4abO9zbr6PW6taHgF24Mwy/LbQ4TC4Aq3tKdKDntxyD+sh7AkSRfJRT2ccMVaHVv2+FfHThd3PKQ==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    dependencies:
+      '@swc/helpers': 0.5.15
+      react: 19.1.0
+    dev: false
+
+  /@react-types/shared@3.30.0(react@19.1.0):
+    resolution: {integrity: sha512-COIazDAx1ncDg046cTJ8SFYsX8aS3lB/08LDnbkH/SkdYrFPWDlXMrO/sUam8j1WWM+PJ+4d1mj7tODIKNiFog==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    dependencies:
+      react: 19.1.0
     dev: false
 
   /@rollup/pluginutils@5.2.0:
@@ -2845,9 +2979,41 @@ packages:
       react-dom: 19.1.0(react@19.1.0)
     dev: false
 
+  /@tanstack/react-virtual@3.13.11(react-dom@19.1.0)(react@19.1.0):
+    resolution: {integrity: sha512-u5EaOSJOq08T9NXFuDopMdxZBNDFuEMohIFFU45fBYDXXh9SjYdbpNq1OLFSOpQnDRPjqgmY96ipZTkzom9t9Q==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+    dependencies:
+      '@tanstack/virtual-core': 3.13.11
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    dev: false
+
   /@tanstack/table-core@8.21.3:
     resolution: {integrity: sha512-ldZXEhOBb8Is7xLs01fR3YEc3DERiz5silj8tnGkFZytt1abEvl/GhUmCE0PMLaMPTa3Jk4HbKmRlHmu+gCftg==}
     engines: {node: '>=12'}
+    dev: false
+
+  /@tanstack/virtual-core@3.13.11:
+    resolution: {integrity: sha512-ORL6UyuZJ0D9X33LDR4TcgcM+K2YiS2j4xbvH1vnhhObwR1Z4dKwPTL/c0kj2Yeb4Yp2lBv1wpyVaqlohk8zpg==}
+    dev: false
+
+  /@tremor/react@3.18.7(react-dom@19.1.0)(react@19.1.0):
+    resolution: {integrity: sha512-nmqvf/1m0GB4LXc7v2ftdfSLoZhy5WLrhV6HNf0SOriE6/l8WkYeWuhQq8QsBjRi94mUIKLJ/VC3/Y/pj6VubQ==}
+    peerDependencies:
+      react: ^18.0.0
+      react-dom: '>=16.6.0'
+    dependencies:
+      '@floating-ui/react': 0.19.2(react-dom@19.1.0)(react@19.1.0)
+      '@headlessui/react': 2.2.0(react-dom@19.1.0)(react@19.1.0)
+      date-fns: 3.6.0
+      react: 19.1.0
+      react-day-picker: 8.10.1(date-fns@3.6.0)(react@19.1.0)
+      react-dom: 19.1.0(react@19.1.0)
+      react-transition-state: 2.3.1(react-dom@19.1.0)(react@19.1.0)
+      recharts: 2.15.3(react-dom@19.1.0)(react@19.1.0)
+      tailwind-merge: 2.6.0
     dev: false
 
   /@tybys/wasm-util@0.9.0:
@@ -3788,6 +3954,10 @@ packages:
 
   /date-fns-jalali@4.1.0-0:
     resolution: {integrity: sha512-hTIP/z+t+qKwBDcmmsnmjWTduxCg+5KfdqWQvb2X/8C9+knYY6epN/pfxdDuyVlSVeFz0sM5eEfwIUQ70U4ckg==}
+    dev: false
+
+  /date-fns@3.6.0:
+    resolution: {integrity: sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==}
     dev: false
 
   /date-fns@4.1.0:
@@ -6254,6 +6424,16 @@ packages:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
     dev: true
 
+  /react-day-picker@8.10.1(date-fns@3.6.0)(react@19.1.0):
+    resolution: {integrity: sha512-TMx7fNbhLk15eqcMt+7Z7S2KF7mfTId/XJDjKE8f+IUcFn0l08/kI4FiYTL/0yuOLmEcbR4Fwe3GJf/NiiMnPA==}
+    peerDependencies:
+      date-fns: ^2.28.0 || ^3.0.0
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+    dependencies:
+      date-fns: 3.6.0
+      react: 19.1.0
+    dev: false
+
   /react-day-picker@9.7.0(react@19.1.0):
     resolution: {integrity: sha512-urlK4C9XJZVpQ81tmVgd2O7lZ0VQldZeHzNejbwLWZSkzHH498KnArT0EHNfKBOWwKc935iMLGZdxXPRISzUxQ==}
     engines: {node: '>=18'}
@@ -6452,6 +6632,16 @@ packages:
       dom-helpers: 5.2.1
       loose-envify: 1.4.0
       prop-types: 15.8.1
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    dev: false
+
+  /react-transition-state@2.3.1(react-dom@19.1.0)(react@19.1.0):
+    resolution: {integrity: sha512-Z48el73x+7HUEM131dof9YpcQ5IlM4xB+pKWH/lX3FhxGfQaNTZa16zb7pWkC/y5btTZzXfCtglIJEGc57giOw==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+    dependencies:
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
     dev: false
@@ -6972,6 +7162,14 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
     dev: true
+
+  /tabbable@6.2.0:
+    resolution: {integrity: sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew==}
+    dev: false
+
+  /tailwind-merge@2.6.0:
+    resolution: {integrity: sha512-P+Vu1qXfzediirmHOC3xKGAYeZtPcV9g76X+xg2FD4tYgR71ewMA35Y3sCz3zhiN/dwefRpJX0yBcgwi1fXNQA==}
+    dev: false
 
   /tailwind-merge@3.3.1:
     resolution: {integrity: sha512-gBXpgUm/3rp1lMZZrM/w7D8GKqshif0zAymAhbCyIt8KMe+0v9DQ7cdYLR4FHH/cKpdTXb+A/tKKU3eolfsI+g==}

--- a/src/actions/financial-actions.ts
+++ b/src/actions/financial-actions.ts
@@ -1,0 +1,395 @@
+import { PrismaClient } from "@/generated/prisma";
+import { getCurrentAppUser } from "./user-actions";
+
+// Prisma client instantiation per request (best practice)
+function getPrismaClient() {
+  return new PrismaClient();
+}
+
+async function getActiveFamilyId(): Promise<string | null> {
+  const appUser = await getCurrentAppUser();
+  return appUser?.familyMemberships[0]?.familyId || null;
+}
+
+export type FinancialOverview = {
+  totalNetWorth: number;
+  totalAssets: number;
+  totalLiabilities: number;
+  monthlyIncome: number;
+  monthlyExpenses: number;
+  savingsRate: number;
+  cashFlow: number;
+  accountBreakdown: {
+    checking: number;
+    savings: number;
+    creditCard: number;
+    investment: number;
+    other: number;
+  };
+  topCategories: {
+    categoryId: string;
+    categoryName: string;
+    amount: number;
+    percentage: number;
+  }[];
+  recentTrend: "up" | "down" | "stable";
+  monthlyGoalProgress: number;
+};
+
+export type AccountTrend = {
+  date: string;
+  balance: number;
+};
+
+export type EnhancedAccount = {
+  id: string;
+  name: string;
+  type: string;
+  balance: number;
+  currency: string;
+  institution?: string | null;
+  color?: string | null;
+  trend: AccountTrend[];
+  monthlyChange: number;
+  monthlyChangePercentage: number;
+  recentTransactionCount: number;
+  status: "healthy" | "attention" | "inactive";
+};
+
+/**
+ * Get comprehensive financial overview metrics
+ */
+export async function getFinancialOverview(): Promise<FinancialOverview> {
+  const familyId = await getActiveFamilyId();
+  if (!familyId) {
+    throw new Error("User not authenticated or no family found");
+  }
+
+  const prisma = getPrismaClient();
+
+  try {
+    // Get current month date range
+    const now = new Date();
+    const startOfMonth = new Date(now.getFullYear(), now.getMonth(), 1);
+    const endOfMonth = new Date(now.getFullYear(), now.getMonth() + 1, 0);
+    const lastMonth = new Date(now.getFullYear(), now.getMonth() - 1, 1);
+    const endOfLastMonth = new Date(now.getFullYear(), now.getMonth(), 0);
+
+    // Get all accounts with balances
+    const accounts = await prisma.financialAccount.findMany({
+      where: {
+        familyId,
+        isActive: true,
+      },
+      select: {
+        id: true,
+        type: true,
+        balance: true,
+      },
+    });
+
+    // Calculate account breakdown
+    const accountBreakdown = accounts.reduce(
+      (acc, account) => {
+        const balance = Number(account.balance);
+        switch (account.type) {
+          case "CHECKING":
+            acc.checking += balance;
+            break;
+          case "SAVINGS":
+            acc.savings += balance;
+            break;
+          case "CREDIT_CARD":
+            acc.creditCard += Math.abs(balance); // Show absolute value for liabilities
+            break;
+          case "INVESTMENT":
+            acc.investment += balance;
+            break;
+          default:
+            acc.other += balance;
+            break;
+        }
+        return acc;
+      },
+      { checking: 0, savings: 0, creditCard: 0, investment: 0, other: 0 }
+    );
+
+    // Calculate totals
+    const totalAssets =
+      accountBreakdown.checking +
+      accountBreakdown.savings +
+      accountBreakdown.investment +
+      accountBreakdown.other;
+    const totalLiabilities = accountBreakdown.creditCard;
+    const totalNetWorth = totalAssets - totalLiabilities;
+
+    // Get monthly transactions for income/expense calculation
+    const currentMonthTransactions = await prisma.transaction.findMany({
+      where: {
+        familyId,
+        date: {
+          gte: startOfMonth,
+          lte: endOfMonth,
+        },
+        status: "RECONCILED",
+      },
+      select: {
+        amount: true,
+        type: true,
+        categoryId: true,
+        category: {
+          select: {
+            name: true,
+          },
+        },
+      },
+    });
+
+    // Calculate monthly income and expenses
+    const monthlyIncome = currentMonthTransactions
+      .filter((t) => t.type === "INCOME")
+      .reduce((sum, t) => sum + Number(t.amount), 0);
+
+    const monthlyExpenses = Math.abs(
+      currentMonthTransactions
+        .filter((t) => t.type === "EXPENSE")
+        .reduce((sum, t) => sum + Number(t.amount), 0)
+    );
+
+    // Calculate savings rate and cash flow
+    const savingsRate =
+      monthlyIncome > 0
+        ? ((monthlyIncome - monthlyExpenses) / monthlyIncome) * 100
+        : 0;
+    const cashFlow = monthlyIncome - monthlyExpenses;
+
+    // Get top spending categories
+    const categorySpending = currentMonthTransactions
+      .filter((t) => t.type === "EXPENSE" && t.categoryId)
+      .reduce(
+        (acc, t) => {
+          const categoryId = t.categoryId!;
+          const categoryName = t.category?.name || "Uncategorized";
+          const amount = Math.abs(Number(t.amount));
+
+          if (!acc[categoryId]) {
+            acc[categoryId] = { categoryId, categoryName, amount: 0 };
+          }
+          acc[categoryId].amount += amount;
+          return acc;
+        },
+        {} as Record<
+          string,
+          { categoryId: string; categoryName: string; amount: number }
+        >
+      );
+
+    const topCategories = Object.values(categorySpending)
+      .sort((a, b) => b.amount - a.amount)
+      .slice(0, 5)
+      .map((cat) => ({
+        ...cat,
+        percentage:
+          monthlyExpenses > 0 ? (cat.amount / monthlyExpenses) * 100 : 0,
+      }));
+
+    // Calculate trend (compare to last month)
+    const lastMonthTransactions = await prisma.transaction.findMany({
+      where: {
+        familyId,
+        date: {
+          gte: lastMonth,
+          lte: endOfLastMonth,
+        },
+        status: "RECONCILED",
+        type: "EXPENSE",
+      },
+      select: {
+        amount: true,
+      },
+    });
+
+    const lastMonthExpenses = Math.abs(
+      lastMonthTransactions.reduce((sum, t) => sum + Number(t.amount), 0)
+    );
+
+    let recentTrend: "up" | "down" | "stable" = "stable";
+    if (monthlyExpenses > lastMonthExpenses * 1.05) {
+      recentTrend = "up";
+    } else if (monthlyExpenses < lastMonthExpenses * 0.95) {
+      recentTrend = "down";
+    }
+
+    // Get goal progress
+    const goals = await prisma.goal.findMany({
+      where: {
+        familyId,
+        isActive: true,
+      },
+      select: {
+        targetAmount: true,
+        currentAmount: true,
+      },
+    });
+
+    const monthlyGoalProgress =
+      goals.length > 0
+        ? goals.reduce((avg, goal) => {
+            const progress =
+              Number(goal.targetAmount) > 0
+                ? (Number(goal.currentAmount) / Number(goal.targetAmount)) * 100
+                : 0;
+            return avg + progress;
+          }, 0) / goals.length
+        : 0;
+
+    return {
+      totalNetWorth,
+      totalAssets,
+      totalLiabilities,
+      monthlyIncome,
+      monthlyExpenses,
+      savingsRate,
+      cashFlow,
+      accountBreakdown,
+      topCategories,
+      recentTrend,
+      monthlyGoalProgress,
+    };
+  } catch (error) {
+    console.error("Error fetching financial overview:", error);
+    throw new Error("Failed to fetch financial overview");
+  } finally {
+    await prisma.$disconnect();
+  }
+}
+
+/**
+ * Get enhanced account data with trends and mini-chart data
+ */
+export async function getEnhancedAccounts(): Promise<EnhancedAccount[]> {
+  const familyId = await getActiveFamilyId();
+  if (!familyId) {
+    return [];
+  }
+
+  const prisma = getPrismaClient();
+
+  try {
+    // Get all accounts
+    const accounts = await prisma.financialAccount.findMany({
+      where: {
+        familyId,
+        isActive: true,
+      },
+      select: {
+        id: true,
+        name: true,
+        type: true,
+        balance: true,
+        currency: true,
+        institution: true,
+        color: true,
+        createdAt: true,
+      },
+      orderBy: {
+        createdAt: "asc",
+      },
+    });
+
+    // Get last 6 months of data for trends (simplified - using creation date as proxy)
+    const sixMonthsAgo = new Date();
+    sixMonthsAgo.setMonth(sixMonthsAgo.getMonth() - 6);
+
+    const enhancedAccounts: EnhancedAccount[] = await Promise.all(
+      accounts.map(async (account) => {
+        // Get recent transactions for this account
+        const recentTransactions = await prisma.transaction.findMany({
+          where: {
+            accountId: account.id,
+            date: {
+              gte: sixMonthsAgo,
+            },
+          },
+          select: {
+            date: true,
+            amount: true,
+          },
+          orderBy: {
+            date: "asc",
+          },
+        });
+
+        // Generate trend data (simplified - using monthly aggregation)
+        const trend: AccountTrend[] = [];
+        const now = new Date();
+        const currentBalance = Number(account.balance);
+
+        // Generate 6 months of trend data (simplified calculation)
+        for (let i = 5; i >= 0; i--) {
+          const date = new Date(now.getFullYear(), now.getMonth() - i, 1);
+          const monthTransactions = recentTransactions.filter((t) => {
+            const transactionDate = new Date(t.date);
+            return (
+              transactionDate.getMonth() === date.getMonth() &&
+              transactionDate.getFullYear() === date.getFullYear()
+            );
+          });
+
+          const monthlyChange = monthTransactions.reduce(
+            (sum, t) => sum + Number(t.amount),
+            0
+          );
+          const estimatedBalance =
+            i === 0
+              ? currentBalance
+              : currentBalance - monthlyChange * (i + 1) * 0.1; // Simplified estimation
+
+          trend.push({
+            date: date.toISOString().split("T")[0],
+            balance: Math.max(0, estimatedBalance),
+          });
+        }
+
+        // Calculate monthly change
+        const lastMonthBalance =
+          trend[trend.length - 2]?.balance || currentBalance;
+        const monthlyChange = currentBalance - lastMonthBalance;
+        const monthlyChangePercentage =
+          lastMonthBalance > 0 ? (monthlyChange / lastMonthBalance) * 100 : 0;
+
+        // Determine account status
+        let status: "healthy" | "attention" | "inactive" = "healthy";
+        if (recentTransactions.length === 0) {
+          status = "inactive";
+        } else if (account.type === "CREDIT_CARD" && currentBalance < -1000) {
+          status = "attention";
+        } else if (account.type === "CHECKING" && currentBalance < 100) {
+          status = "attention";
+        }
+
+        return {
+          id: account.id,
+          name: account.name,
+          type: account.type,
+          balance: currentBalance,
+          currency: account.currency,
+          institution: account.institution,
+          color: account.color,
+          trend,
+          monthlyChange,
+          monthlyChangePercentage,
+          recentTransactionCount: recentTransactions.length,
+          status,
+        };
+      })
+    );
+
+    return enhancedAccounts;
+  } catch (error) {
+    console.error("Error fetching enhanced accounts:", error);
+    return [];
+  } finally {
+    await prisma.$disconnect();
+  }
+}

--- a/src/app/dashboard/financial/page.tsx
+++ b/src/app/dashboard/financial/page.tsx
@@ -1,8 +1,10 @@
+import { FinancialTabs } from "@/components/financial/financial-tabs";
 import {
+  SuspendedFinancialOverviewSection,
   SuspendedAccountsHeaderSection,
   SuspendedAccountsFilterSection,
-  SuspendedAccountsGridSection,
-} from "@/components/accounts/accounts-async-components";
+  SuspendedEnhancedAccountsGridSection,
+} from "@/components/financial/financial-async-components";
 
 interface FinancialPageProps {
   searchParams: {
@@ -12,20 +14,34 @@ interface FinancialPageProps {
   };
 }
 
-export default async function FinancialPage({ searchParams }: FinancialPageProps) {
+export default async function FinancialPage({
+  searchParams,
+}: FinancialPageProps) {
+  const awaitedSearchParams = await searchParams;
+
   const filters = {
-    search: searchParams.search,
-    type: searchParams.type,
-    institution: searchParams.institution,
+    search: awaitedSearchParams.search,
+    type: awaitedSearchParams.type,
+    institution: awaitedSearchParams.institution,
   };
 
-  const searchKey = JSON.stringify(searchParams);
+  const searchKey = JSON.stringify(awaitedSearchParams);
 
   return (
     <div className="flex flex-col gap-6 p-6">
-      <SuspendedAccountsHeaderSection />
-      <SuspendedAccountsFilterSection filters={filters} />
-      <SuspendedAccountsGridSection key={`grid-${searchKey}`} filters={filters} />
+      <FinancialTabs
+        header={<SuspendedAccountsHeaderSection />}
+        accountsContent={
+          <>
+            <SuspendedAccountsFilterSection filters={filters} />
+            <SuspendedEnhancedAccountsGridSection
+              key={`grid-${searchKey}`}
+              filters={filters}
+            />
+          </>
+        }
+        overviewContent={<SuspendedFinancialOverviewSection />}
+      />
     </div>
   );
 }

--- a/src/app/dashboard/financial/page.tsx
+++ b/src/app/dashboard/financial/page.tsx
@@ -1,0 +1,31 @@
+import {
+  SuspendedAccountsHeaderSection,
+  SuspendedAccountsFilterSection,
+  SuspendedAccountsGridSection,
+} from "@/components/accounts/accounts-async-components";
+
+interface FinancialPageProps {
+  searchParams: {
+    search?: string;
+    type?: string;
+    institution?: string;
+  };
+}
+
+export default async function FinancialPage({ searchParams }: FinancialPageProps) {
+  const filters = {
+    search: searchParams.search,
+    type: searchParams.type,
+    institution: searchParams.institution,
+  };
+
+  const searchKey = JSON.stringify(searchParams);
+
+  return (
+    <div className="flex flex-col gap-6 p-6">
+      <SuspendedAccountsHeaderSection />
+      <SuspendedAccountsFilterSection filters={filters} />
+      <SuspendedAccountsGridSection key={`grid-${searchKey}`} filters={filters} />
+    </div>
+  );
+}

--- a/src/components/accounts/accounts-async-components.tsx
+++ b/src/components/accounts/accounts-async-components.tsx
@@ -1,0 +1,91 @@
+import { Suspense } from "react";
+import { getFinancialAccounts } from "@/actions/dashboard-actions";
+import { AccountsHeaderSection } from "./accounts-header-section";
+import { AccountsFilterSection } from "./accounts-filter-section";
+import { AccountsGrid } from "./accounts-grid";
+import {
+  TransactionTableSkeleton,
+  HeaderSkeleton,
+} from "../dashboard/skeletons";
+
+interface FilterValues {
+  search?: string;
+  type?: string;
+  institution?: string;
+}
+
+type Account = Awaited<ReturnType<typeof getFinancialAccounts>>[number] & {
+  balance: number;
+};
+
+function normalizeAccounts(accounts: Awaited<ReturnType<typeof getFinancialAccounts>>): Account[] {
+  return accounts.map((account) => ({
+    ...account,
+    balance: Number(account.balance),
+  }));
+}
+
+function filterAccounts(accounts: Account[], filters: FilterValues) {
+  return accounts.filter((account) => {
+    const matchesSearch = filters.search
+      ? account.name.toLowerCase().includes(filters.search.toLowerCase()) ||
+        (account.institution ?? "").toLowerCase().includes(filters.search.toLowerCase())
+      : true;
+    const matchesType = filters.type ? account.type === filters.type : true;
+    const matchesInst = filters.institution ? account.institution === filters.institution : true;
+    return matchesSearch && matchesType && matchesInst;
+  });
+}
+
+async function AsyncAccountsHeaderSection() {
+  return <AccountsHeaderSection />;
+}
+
+async function AsyncAccountsFilterSection({ filters }: { filters: FilterValues }) {
+  const rawAccounts = await getFinancialAccounts();
+  const accounts = normalizeAccounts(rawAccounts);
+  const filtered = filterAccounts(accounts, filters);
+  const types = Array.from(new Set(accounts.map((a) => a.type)));
+  const institutions = Array.from(
+    new Set(accounts.map((a) => a.institution).filter(Boolean))
+  ) as string[];
+  return (
+    <AccountsFilterSection
+      types={types}
+      institutions={institutions}
+      currentFilters={filters}
+      totalCount={filtered.length}
+    />
+  );
+}
+
+async function AsyncAccountsGridSection({ filters }: { filters: FilterValues }) {
+  const rawAccounts = await getFinancialAccounts();
+  const accounts = normalizeAccounts(rawAccounts);
+  const filtered = filterAccounts(accounts, filters);
+  return <AccountsGrid accounts={filtered} />;
+}
+
+export function SuspendedAccountsHeaderSection() {
+  return (
+    <Suspense fallback={<HeaderSkeleton />}>
+      <AsyncAccountsHeaderSection />
+    </Suspense>
+  );
+}
+
+export function SuspendedAccountsFilterSection({ filters }: { filters: FilterValues }) {
+  return (
+    <Suspense fallback={<div className="h-16 animate-pulse bg-muted rounded-lg" />}>
+      <AsyncAccountsFilterSection filters={filters} />
+    </Suspense>
+  );
+}
+
+export function SuspendedAccountsGridSection({ filters }: { filters: FilterValues }) {
+  return (
+    <Suspense fallback={<TransactionTableSkeleton />}>
+      <AsyncAccountsGridSection filters={filters} />
+    </Suspense>
+  );
+}

--- a/src/components/accounts/accounts-filter-section.tsx
+++ b/src/components/accounts/accounts-filter-section.tsx
@@ -1,0 +1,171 @@
+"use client";
+
+import { useRouter, useSearchParams } from "next/navigation";
+import { useCallback, useTransition, useState, useRef, useEffect } from "react";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Button } from "@/components/ui/button";
+import { IconSearch, IconRefresh } from "@tabler/icons-react";
+
+interface AccountsFilterSectionProps {
+  types: string[];
+  institutions: string[];
+  currentFilters: { search?: string; type?: string; institution?: string };
+  totalCount: number;
+}
+
+export function AccountsFilterSection({
+  types,
+  institutions,
+  currentFilters,
+  totalCount,
+}: AccountsFilterSectionProps) {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const [isPending, startTransition] = useTransition();
+  const [localSearch, setLocalSearch] = useState(currentFilters.search || "");
+  const searchTimeoutRef = useRef<NodeJS.Timeout>();
+
+  const handleSearchChange = useCallback(
+    (value: string) => {
+      setLocalSearch(value);
+      if (searchTimeoutRef.current) clearTimeout(searchTimeoutRef.current);
+      searchTimeoutRef.current = setTimeout(() => {
+        const params = new URLSearchParams(searchParams.toString());
+        if (value && value.trim() !== "") {
+          params.set("search", value);
+        } else {
+          params.delete("search");
+        }
+        startTransition(() => {
+          router.push(`?${params.toString()}`);
+        });
+      }, 300);
+    },
+    [router, searchParams, startTransition]
+  );
+
+  const updateFilter = useCallback(
+    (key: string, value: string | undefined) => {
+      const params = new URLSearchParams(searchParams.toString());
+      if (value && value !== "all") {
+        params.set(key, value);
+      } else {
+        params.delete(key);
+      }
+      startTransition(() => {
+        router.push(`?${params.toString()}`);
+      });
+    },
+    [router, searchParams, startTransition]
+  );
+
+  const clearFilters = useCallback(() => {
+    setLocalSearch("");
+    if (searchTimeoutRef.current) clearTimeout(searchTimeoutRef.current);
+    startTransition(() => {
+      router.push(window.location.pathname);
+    });
+  }, [router, startTransition]);
+
+  useEffect(() => {
+    setLocalSearch(currentFilters.search || "");
+  }, [currentFilters.search]);
+
+  const activeFiltersCount = [
+    localSearch || undefined,
+    currentFilters.type,
+    currentFilters.institution,
+  ].filter(Boolean).length;
+
+  return (
+    <div className="space-y-4 border rounded-lg p-4">
+      <div className="flex flex-col sm:flex-row gap-3">
+        <div className="flex-1 min-w-0">
+          <div className="relative">
+            <IconSearch className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+            <Input
+              placeholder="Search accounts..."
+              className="pl-10 bg-background"
+              value={localSearch}
+              onChange={(e) => handleSearchChange(e.target.value)}
+              disabled={isPending}
+            />
+          </div>
+        </div>
+
+        <div className="w-full sm:w-[140px]">
+          <Select
+            value={currentFilters.type || "all"}
+            onValueChange={(val) => updateFilter("type", val === "all" ? undefined : val)}
+            disabled={isPending}
+          >
+            <SelectTrigger className="bg-background">
+              <SelectValue placeholder="Type" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">All types</SelectItem>
+              {types.map((t) => (
+                <SelectItem key={t} value={t}>
+                  {t.replace(/_/g, " ")}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+
+        <div className="w-full sm:w-[140px]">
+          <Select
+            value={currentFilters.institution || "all"}
+            onValueChange={(val) =>
+              updateFilter("institution", val === "all" ? undefined : val)
+            }
+            disabled={isPending}
+          >
+            <SelectTrigger className="bg-background">
+              <SelectValue placeholder="Institution" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">All institutions</SelectItem>
+              {institutions.map((inst) => (
+                <SelectItem key={inst} value={inst}>
+                  {inst}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+
+        {activeFiltersCount > 0 && (
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={clearFilters}
+            disabled={isPending}
+            className="gap-2"
+          >
+            <IconRefresh className="h-4 w-4" />
+            Reset
+          </Button>
+        )}
+      </div>
+
+      <div className="flex items-center justify-between text-sm text-muted-foreground border-t pt-3">
+        <span>
+          {isPending ? "Filtering..." : `${totalCount} account${totalCount !== 1 ? "s" : ""} found`}
+        </span>
+        {activeFiltersCount > 0 && (
+          <span className="text-xs">
+            {activeFiltersCount} filter{activeFiltersCount !== 1 ? "s" : ""} active
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/accounts/accounts-grid.tsx
+++ b/src/components/accounts/accounts-grid.tsx
@@ -1,0 +1,52 @@
+interface Account {
+  id: string;
+  name: string;
+  type: string;
+  balance: number;
+  currency: string;
+  institution?: string | null;
+  color?: string | null;
+}
+
+function formatCurrency(amount: number, currency: string) {
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency,
+  }).format(amount);
+}
+
+export function AccountsGrid({ accounts }: { accounts: Account[] }) {
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+      {accounts.map((account) => (
+        <div
+          key={account.id}
+          className="border rounded-lg p-6 flex flex-col gap-2"
+        >
+          <div className="flex items-center justify-between">
+            <h3 className="font-semibold flex items-center gap-2">
+              {account.color && (
+                <span
+                  className="inline-block h-2 w-2 rounded-full"
+                  style={{ backgroundColor: account.color }}
+                />
+              )}
+              {account.name}
+            </h3>
+            <span className="text-xs text-muted-foreground">
+              {account.type.replace(/_/g, " ")}
+            </span>
+          </div>
+          {account.institution && (
+            <p className="text-sm text-muted-foreground">
+              {account.institution}
+            </p>
+          )}
+          <p className="text-xl font-bold">
+            {formatCurrency(account.balance, account.currency)}
+          </p>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/components/accounts/accounts-header-section.tsx
+++ b/src/components/accounts/accounts-header-section.tsx
@@ -1,0 +1,8 @@
+export function AccountsHeaderSection() {
+  return (
+    <div className="flex flex-col gap-2">
+      <h1 className="text-3xl font-bold tracking-tight">Financial Accounts</h1>
+      <p className="text-muted-foreground">View and manage all your accounts</p>
+    </div>
+  );
+}

--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -3,12 +3,10 @@
 import * as React from "react";
 import {
   IconCamera,
-  IconChartBar,
   IconCreditCard,
   IconDashboard,
   IconFileAi,
   IconFileDescription,
-  IconFolder,
   IconHelp,
   IconPigMoney,
   IconSearch,
@@ -40,6 +38,11 @@ const data = {
       icon: IconDashboard,
     },
     {
+      title: "Accounts",
+      url: "/dashboard/financial",
+      icon: IconWallet,
+    },
+    {
       title: "Transactions",
       url: "/dashboard/transactions",
       icon: IconCreditCard,
@@ -49,16 +52,16 @@ const data = {
       url: "/investments",
       icon: IconTrendingUp,
     },
-    {
-      title: "Analytics",
-      url: "/analytics",
-      icon: IconChartBar,
-    },
-    {
-      title: "Projects",
-      url: "/projects",
-      icon: IconFolder,
-    },
+    // {
+    //   title: "Analytics",
+    //   url: "/analytics",
+    //   icon: IconChartBar,
+    // },
+    // {
+    //   title: "Projects",
+    //   url: "/projects",
+    //   icon: IconFolder,
+    // },
   ],
   navClouds: [
     {

--- a/src/components/financial/charts/account-breakdown-chart.tsx
+++ b/src/components/financial/charts/account-breakdown-chart.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import { DonutChart } from "@tremor/react";
+
+interface AccountBreakdownData {
+  name: string;
+  value: number;
+  share: string;
+  borderColor: string;
+}
+
+interface AccountBreakdownChartProps {
+  data: AccountBreakdownData[];
+}
+
+function classNames(...classes: (string | undefined | boolean)[]) {
+  return classes.filter(Boolean).join(" ");
+}
+
+const currencyFormatter = (number: number) => {
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+  }).format(number);
+};
+
+export function AccountBreakdownChart({ data }: AccountBreakdownChartProps) {
+  // Convert data format for Tremor chart
+  const chartData = data.map((item) => ({
+    name: item.name,
+    amount: item.value,
+    share: item.share,
+    borderColor: item.borderColor,
+  }));
+
+  // Extract colors for the chart (Tremor accepts color names)
+  const colorMap: Record<string, string> = {
+    "#0066CC": "blue",
+    "#28A745": "green",
+    "#6F42C1": "purple",
+    "#FFC107": "yellow",
+    "#DC3545": "red",
+    "#17A2B8": "cyan",
+  };
+
+  const colors = data.map((item) => {
+    // Extract color from the data or fall back to default
+    const colorKey = Object.keys(colorMap).find(
+      (key) => item.borderColor?.includes(key) || false
+    );
+    return colorKey ? colorMap[colorKey] : "gray";
+  });
+
+  return (
+    <div className="grid grid-cols-1 gap-0 sm:grid-cols-2 sm:gap-8">
+      <DonutChart
+        data={chartData}
+        category="amount"
+        index="name"
+        valueFormatter={currencyFormatter}
+        showTooltip={true}
+        className="h-40"
+        colors={
+          colors.length > 0 ? colors : ["blue", "green", "purple", "yellow"]
+        }
+      />
+      <div className="flex items-center">
+        <ul role="list" className="space-y-3">
+          {chartData.map((item) => (
+            <li key={item.name} className="flex space-x-3">
+              <span
+                className={classNames(item.borderColor, "w-1 shrink-0 rounded")}
+              />
+              <div>
+                <p className="text-sm font-medium text-foreground">
+                  {currencyFormatter(item.amount)}{" "}
+                  <span className="font-normal">({item.share})</span>
+                </p>
+                <p className="mt-0.5 whitespace-nowrap text-sm text-muted-foreground">
+                  {item.name}
+                </p>
+              </div>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+}

--- a/src/components/financial/charts/account-mini-chart.tsx
+++ b/src/components/financial/charts/account-mini-chart.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { LineChart, Line, ResponsiveContainer, Tooltip } from "recharts";
+
+interface TrendData {
+  date: string;
+  balance: number;
+}
+
+interface AccountMiniChartProps {
+  data: TrendData[];
+  color?: string;
+  currency?: string;
+}
+
+function formatCurrency(amount: number, currency: string = "USD") {
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency,
+  }).format(amount);
+}
+
+export function AccountMiniChart({
+  data,
+  color = "#0066CC",
+  currency = "USD",
+}: AccountMiniChartProps) {
+  return (
+    <div className="h-16 w-full">
+      <ResponsiveContainer width="100%" height="100%">
+        <LineChart data={data}>
+          <Line
+            type="monotone"
+            dataKey="balance"
+            stroke={color}
+            strokeWidth={2}
+            dot={false}
+            activeDot={{ r: 3 }}
+          />
+          <Tooltip
+            content={({ active, payload, label }) => {
+              if (active && payload && payload.length) {
+                return (
+                  <div className="bg-background border rounded-lg p-2 shadow-md">
+                    <p className="text-xs text-muted-foreground">{label}</p>
+                    <p className="text-sm font-medium">
+                      {formatCurrency(payload[0].value as number, currency)}
+                    </p>
+                  </div>
+                );
+              }
+              return null;
+            }}
+          />
+        </LineChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}

--- a/src/components/financial/enhanced-accounts-grid.tsx
+++ b/src/components/financial/enhanced-accounts-grid.tsx
@@ -1,0 +1,150 @@
+import { Badge } from "@/components/ui/badge";
+import {
+  TrendingUp,
+  TrendingDown,
+  AlertTriangle,
+  Activity,
+} from "lucide-react";
+import { AccountMiniChart } from "./charts/account-mini-chart";
+import type { EnhancedAccount } from "@/actions/financial-actions";
+
+interface EnhancedAccountsGridProps {
+  accounts: EnhancedAccount[];
+}
+
+function formatCurrency(amount: number, currency: string = "USD") {
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency,
+  }).format(amount);
+}
+
+function formatPercentage(value: number) {
+  return `${value >= 0 ? "+" : ""}${value.toFixed(1)}%`;
+}
+
+export function EnhancedAccountsGrid({ accounts }: EnhancedAccountsGridProps) {
+  const getStatusColor = (status: string) => {
+    switch (status) {
+      case "healthy":
+        return "bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-300";
+      case "attention":
+        return "bg-orange-100 text-orange-800 dark:bg-orange-900 dark:text-orange-300";
+      case "inactive":
+        return "bg-gray-100 text-gray-800 dark:bg-gray-900 dark:text-gray-300";
+      default:
+        return "bg-gray-100 text-gray-800 dark:bg-gray-900 dark:text-gray-300";
+    }
+  };
+
+  const getStatusIcon = (status: string) => {
+    switch (status) {
+      case "healthy":
+        return <Activity className="h-3 w-3" />;
+      case "attention":
+        return <AlertTriangle className="h-3 w-3" />;
+      case "inactive":
+        return <TrendingDown className="h-3 w-3" />;
+      default:
+        return <Activity className="h-3 w-3" />;
+    }
+  };
+
+  const getTrendIcon = (change: number) => {
+    if (change > 0) {
+      return <TrendingUp className="h-3 w-3 text-green-600" />;
+    } else if (change < 0) {
+      return <TrendingDown className="h-3 w-3 text-red-600" />;
+    }
+    return null;
+  };
+
+  const getTrendColor = (change: number) => {
+    if (change > 0) return "text-green-600";
+    if (change < 0) return "text-red-600";
+    return "text-muted-foreground";
+  };
+
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+      {accounts.map((account) => (
+        <div
+          key={account.id}
+          className="space-y-4 border rounded-lg p-4 relative"
+        >
+          {/* Header */}
+          <div className="flex items-start justify-between">
+            <div className="space-y-1">
+              <h3 className="text-base font-semibold flex items-center gap-2">
+                {account.color && (
+                  <span
+                    className="inline-block h-2 w-2 rounded-full"
+                    style={{ backgroundColor: account.color }}
+                  />
+                )}
+                {account.name}
+              </h3>
+              <div className="flex items-center gap-2">
+                <span className="text-xs text-muted-foreground">
+                  {account.type.replace(/_/g, " ")}
+                </span>
+                <Badge
+                  variant="secondary"
+                  className={`text-xs ${getStatusColor(account.status)}`}
+                >
+                  {getStatusIcon(account.status)}
+                  <span className="ml-1 capitalize">{account.status}</span>
+                </Badge>
+              </div>
+            </div>
+          </div>
+          {account.institution && (
+            <p className="text-xs text-muted-foreground">
+              {account.institution}
+            </p>
+          )}
+
+          {/* Balance */}
+          <div className="space-y-1">
+            <p className="text-2xl font-bold">
+              {formatCurrency(account.balance, account.currency)}
+            </p>
+            <div className="flex items-center gap-2">
+              {getTrendIcon(account.monthlyChange)}
+              <span
+                className={`text-sm ${getTrendColor(account.monthlyChange)}`}
+              >
+                {formatCurrency(Math.abs(account.monthlyChange))} (
+                {formatPercentage(account.monthlyChangePercentage)})
+              </span>
+              <span className="text-xs text-muted-foreground">this month</span>
+            </div>
+          </div>
+
+          {/* Mini Chart */}
+          <AccountMiniChart
+            data={account.trend}
+            color={account.color || "#0066CC"}
+            currency={account.currency}
+          />
+
+          {/* Transaction Activity */}
+          <div className="flex items-center justify-between text-xs text-muted-foreground">
+            <span>{account.recentTransactionCount} transactions</span>
+            <span>last 6 months</span>
+          </div>
+        </div>
+      ))}
+
+      {accounts.length === 0 && (
+        <div className="col-span-full">
+          <div className="space-y-4 border rounded-lg p-6">
+            <div className="flex items-center justify-center py-8">
+              <p className="text-muted-foreground">No accounts found</p>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/financial/financial-async-components.tsx
+++ b/src/components/financial/financial-async-components.tsx
@@ -1,0 +1,134 @@
+import { Suspense } from "react";
+import {
+  getFinancialOverview,
+  getEnhancedAccounts,
+} from "@/actions/financial-actions";
+import { FinancialOverviewSection } from "./financial-overview-section";
+import { EnhancedAccountsGrid } from "./enhanced-accounts-grid";
+import { AccountsHeaderSection } from "../accounts/accounts-header-section";
+import { AccountsFilterSection } from "../accounts/accounts-filter-section";
+import {
+  TransactionTableSkeleton,
+  HeaderSkeleton,
+  MetricsSkeleton,
+} from "../dashboard/skeletons";
+
+interface FilterValues {
+  search?: string;
+  type?: string;
+  institution?: string;
+}
+
+function normalizeAccounts(
+  accounts: Awaited<ReturnType<typeof getEnhancedAccounts>>
+) {
+  return accounts.map((account) => ({
+    ...account,
+    balance: Number(account.balance),
+  }));
+}
+
+function filterAccounts(
+  accounts: ReturnType<typeof normalizeAccounts>,
+  filters: FilterValues
+) {
+  return accounts.filter((account) => {
+    const matchesSearch = filters.search
+      ? account.name.toLowerCase().includes(filters.search.toLowerCase()) ||
+        (account.institution ?? "")
+          .toLowerCase()
+          .includes(filters.search.toLowerCase())
+      : true;
+    const matchesType = filters.type ? account.type === filters.type : true;
+    const matchesInst = filters.institution
+      ? account.institution === filters.institution
+      : true;
+    return matchesSearch && matchesType && matchesInst;
+  });
+}
+
+async function AsyncFinancialOverviewSection() {
+  const overview = await getFinancialOverview();
+  return <FinancialOverviewSection overview={overview} />;
+}
+
+async function AsyncAccountsHeaderSection() {
+  return <AccountsHeaderSection />;
+}
+
+async function AsyncAccountsFilterSection({
+  filters,
+}: {
+  filters: FilterValues;
+}) {
+  const rawAccounts = await getEnhancedAccounts();
+  const accounts = normalizeAccounts(rawAccounts);
+  const filtered = filterAccounts(accounts, filters);
+  const types = Array.from(new Set(accounts.map((a) => a.type)));
+  const institutions = Array.from(
+    new Set(accounts.map((a) => a.institution).filter(Boolean))
+  ) as string[];
+
+  return (
+    <AccountsFilterSection
+      types={types}
+      institutions={institutions}
+      currentFilters={filters}
+      totalCount={filtered.length}
+    />
+  );
+}
+
+async function AsyncEnhancedAccountsGridSection({
+  filters,
+}: {
+  filters: FilterValues;
+}) {
+  const rawAccounts = await getEnhancedAccounts();
+  const accounts = normalizeAccounts(rawAccounts);
+  const filtered = filterAccounts(accounts, filters);
+  return <EnhancedAccountsGrid accounts={filtered} />;
+}
+
+// Exported components with Suspense boundaries
+export function SuspendedFinancialOverviewSection() {
+  return (
+    <Suspense fallback={<MetricsSkeleton />}>
+      <AsyncFinancialOverviewSection />
+    </Suspense>
+  );
+}
+
+export function SuspendedAccountsHeaderSection() {
+  return (
+    <Suspense fallback={<HeaderSkeleton />}>
+      <AsyncAccountsHeaderSection />
+    </Suspense>
+  );
+}
+
+export function SuspendedAccountsFilterSection({
+  filters,
+}: {
+  filters: FilterValues;
+}) {
+  return (
+    <Suspense
+      fallback={<div className="h-16 animate-pulse bg-muted rounded-lg" />}
+    >
+      <AsyncAccountsFilterSection filters={filters} />
+    </Suspense>
+  );
+}
+
+export function SuspendedEnhancedAccountsGridSection({
+  filters,
+}: {
+  filters: FilterValues;
+}) {
+  return (
+    <Suspense fallback={<TransactionTableSkeleton />}>
+      <AsyncEnhancedAccountsGridSection filters={filters} />
+    </Suspense>
+  );
+}

--- a/src/components/financial/financial-overview-section.tsx
+++ b/src/components/financial/financial-overview-section.tsx
@@ -1,0 +1,253 @@
+import { Badge } from "@/components/ui/badge";
+import { Progress } from "@/components/ui/progress";
+import {
+  TrendingUp,
+  TrendingDown,
+  Minus,
+  PiggyBank,
+  Target,
+} from "lucide-react";
+import { AccountBreakdownChart } from "./charts/account-breakdown-chart";
+import type { FinancialOverview } from "@/actions/financial-actions";
+
+interface FinancialOverviewSectionProps {
+  overview: FinancialOverview;
+}
+
+function formatCurrency(amount: number, currency: string = "USD") {
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency,
+  }).format(amount);
+}
+
+function formatPercentage(value: number) {
+  return `${value.toFixed(1)}%`;
+}
+
+export function FinancialOverviewSection({
+  overview,
+}: FinancialOverviewSectionProps) {
+  const {
+    totalNetWorth,
+    totalAssets,
+    totalLiabilities,
+    monthlyIncome,
+    monthlyExpenses,
+    savingsRate,
+    cashFlow,
+    accountBreakdown,
+    topCategories,
+    recentTrend,
+    monthlyGoalProgress,
+  } = overview;
+
+  // Prepare data for pie chart
+  const totalAccountValue =
+    accountBreakdown.checking +
+    accountBreakdown.savings +
+    accountBreakdown.investment +
+    accountBreakdown.other;
+
+  const pieData = [
+    {
+      name: "Checking",
+      value: accountBreakdown.checking,
+      share:
+        totalAccountValue > 0
+          ? `${((accountBreakdown.checking / totalAccountValue) * 100).toFixed(1)}%`
+          : "0%",
+      borderColor: "bg-blue-500",
+    },
+    {
+      name: "Savings",
+      value: accountBreakdown.savings,
+      share:
+        totalAccountValue > 0
+          ? `${((accountBreakdown.savings / totalAccountValue) * 100).toFixed(1)}%`
+          : "0%",
+      borderColor: "bg-green-500",
+    },
+    {
+      name: "Investment",
+      value: accountBreakdown.investment,
+      share:
+        totalAccountValue > 0
+          ? `${((accountBreakdown.investment / totalAccountValue) * 100).toFixed(1)}%`
+          : "0%",
+      borderColor: "bg-purple-500",
+    },
+    {
+      name: "Other",
+      value: accountBreakdown.other,
+      share:
+        totalAccountValue > 0
+          ? `${((accountBreakdown.other / totalAccountValue) * 100).toFixed(1)}%`
+          : "0%",
+      borderColor: "bg-yellow-500",
+    },
+  ].filter((item) => item.value > 0);
+
+  const getTrendIcon = (trend: string) => {
+    switch (trend) {
+      case "up":
+        return <TrendingUp className="h-4 w-4 text-red-600" />;
+      case "down":
+        return <TrendingDown className="h-4 w-4 text-green-600" />;
+      default:
+        return <Minus className="h-4 w-4 text-muted-foreground" />;
+    }
+  };
+
+  const getTrendColor = (trend: string) => {
+    switch (trend) {
+      case "up":
+        return "text-red-600";
+      case "down":
+        return "text-green-600";
+      default:
+        return "text-muted-foreground";
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      {/* Main Metrics Row */}
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
+        {/* Net Worth */}
+        <div className="space-y-4 border rounded-lg p-4">
+          <h3 className="text-sm font-medium text-muted-foreground">
+            Net Worth
+          </h3>
+          <div className="space-y-1">
+            <p className="text-2xl font-bold">
+              {formatCurrency(totalNetWorth)}
+            </p>
+            <div className="flex items-center gap-2 text-xs">
+              <span className="text-muted-foreground">Assets:</span>
+              <span className="font-medium">{formatCurrency(totalAssets)}</span>
+            </div>
+            {totalLiabilities > 0 && (
+              <div className="flex items-center gap-2 text-xs">
+                <span className="text-muted-foreground">Liabilities:</span>
+                <span className="font-medium text-red-600">
+                  {formatCurrency(totalLiabilities)}
+                </span>
+              </div>
+            )}
+          </div>
+        </div>
+
+        {/* Monthly Cash Flow */}
+        <div className="space-y-4 border rounded-lg p-4">
+          <h3 className="text-sm font-medium text-muted-foreground">
+            Monthly Cash Flow
+          </h3>
+          <div className="space-y-1">
+            <p
+              className={`text-2xl font-bold ${cashFlow >= 0 ? "text-green-600" : "text-red-600"}`}
+            >
+              {formatCurrency(cashFlow)}
+            </p>
+            <div className="flex items-center gap-2 text-xs">
+              <span className="text-green-600">
+                +{formatCurrency(monthlyIncome)}
+              </span>
+              <span className="text-muted-foreground">income</span>
+            </div>
+            <div className="flex items-center gap-2 text-xs">
+              <span className="text-red-600">
+                -{formatCurrency(monthlyExpenses)}
+              </span>
+              <span className="text-muted-foreground">expenses</span>
+            </div>
+          </div>
+        </div>
+
+        {/* Savings Rate */}
+        <div className="space-y-4 border rounded-lg p-4">
+          <h3 className="text-sm font-medium text-muted-foreground">
+            Savings Rate
+          </h3>
+          <div className="space-y-3">
+            <p className="text-2xl font-bold">
+              {formatPercentage(savingsRate)}
+            </p>
+            <Progress value={Math.min(savingsRate, 100)} className="h-2" />
+            <div className="flex items-center gap-1 text-xs text-muted-foreground">
+              <PiggyBank className="h-3 w-3" />
+              <span>Target: 20%</span>
+            </div>
+          </div>
+        </div>
+
+        {/* Goals Progress */}
+        <div className="space-y-4 border rounded-lg p-4">
+          <h3 className="text-sm font-medium text-muted-foreground">
+            Goals Progress
+          </h3>
+          <div className="space-y-3">
+            <p className="text-2xl font-bold">
+              {formatPercentage(monthlyGoalProgress)}
+            </p>
+            <Progress
+              value={Math.min(monthlyGoalProgress, 100)}
+              className="h-2"
+            />
+            <div className="flex items-center gap-1 text-xs text-muted-foreground">
+              <Target className="h-3 w-3" />
+              <span>Average progress</span>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Charts Row */}
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        {/* Account Breakdown Chart */}
+        <div className="space-y-4 border rounded-lg p-6">
+          <h3 className="text-lg font-semibold">Account Breakdown</h3>
+          <AccountBreakdownChart data={pieData} />
+        </div>
+
+        {/* Top Categories */}
+        <div className="space-y-4 border rounded-lg p-6">
+          <div className="flex items-center justify-between">
+            <h3 className="text-lg font-semibold">Top Spending Categories</h3>
+            <div className="flex items-center gap-1">
+              {getTrendIcon(recentTrend)}
+              <span className={`text-sm ${getTrendColor(recentTrend)}`}>
+                vs last month
+              </span>
+            </div>
+          </div>
+          <div className="space-y-4">
+            {topCategories.map((category) => (
+              <div key={category.categoryId} className="space-y-2">
+                <div className="flex items-center justify-between">
+                  <span className="text-sm font-medium">
+                    {category.categoryName}
+                  </span>
+                  <div className="flex items-center gap-2">
+                    <span className="text-sm font-bold">
+                      {formatCurrency(category.amount)}
+                    </span>
+                    <Badge variant="secondary" className="text-xs">
+                      {formatPercentage(category.percentage)}
+                    </Badge>
+                  </div>
+                </div>
+                <Progress value={category.percentage} className="h-2" />
+              </div>
+            ))}
+            {topCategories.length === 0 && (
+              <p className="text-sm text-muted-foreground text-center py-4">
+                No spending data for this month
+              </p>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/financial/financial-tabs.tsx
+++ b/src/components/financial/financial-tabs.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { useState, ReactNode } from "react";
+import {
+  TabNavigation,
+  TabNavigationLink,
+} from "@/components/ui/tab-navigation";
+
+interface FinancialTabsProps {
+  header: ReactNode;
+  accountsContent: ReactNode;
+  overviewContent: ReactNode;
+}
+
+export function FinancialTabs({
+  header,
+  accountsContent,
+  overviewContent,
+}: FinancialTabsProps) {
+  const [activeTab, setActiveTab] = useState<"accounts" | "overview">(
+    "accounts"
+  );
+
+  return (
+    <div className="space-y-6">
+      {/* Header (shown on all tabs) */}
+      {header}
+
+      {/* Tab Navigation */}
+      <TabNavigation>
+        <TabNavigationLink
+          active={activeTab === "accounts"}
+          onClick={() => setActiveTab("accounts")}
+          className="cursor-pointer"
+        >
+          Accounts
+        </TabNavigationLink>
+        <TabNavigationLink
+          active={activeTab === "overview"}
+          onClick={() => setActiveTab("overview")}
+          className="cursor-pointer"
+        >
+          Overview
+        </TabNavigationLink>
+      </TabNavigation>
+
+      {/* Tab Content */}
+      {activeTab === "accounts" && (
+        <div className="space-y-6">{accountsContent}</div>
+      )}
+
+      {activeTab === "overview" && (
+        <div className="space-y-6">{overviewContent}</div>
+      )}
+    </div>
+  );
+}

--- a/src/components/ui/tab-navigation.tsx
+++ b/src/components/ui/tab-navigation.tsx
@@ -1,0 +1,101 @@
+import React from "react";
+import * as NavigationMenuPrimitives from "@radix-ui/react-navigation-menu";
+
+import { cn } from "@/lib/utils";
+
+function getSubtree(
+  options: { asChild: boolean | undefined; children: React.ReactNode },
+  content: React.ReactNode | ((children: React.ReactNode) => React.ReactNode)
+) {
+  const { asChild, children } = options;
+  if (!asChild)
+    return typeof content === "function" ? content(children) : content;
+
+  const firstChild = React.Children.only(children) as React.ReactElement<{
+    children?: React.ReactNode;
+  }>;
+  return React.cloneElement(firstChild, {
+    children:
+      typeof content === "function"
+        ? content(firstChild.props.children)
+        : content,
+  });
+}
+
+const TabNavigation = React.forwardRef<
+  React.ElementRef<typeof NavigationMenuPrimitives.Root>,
+  Omit<
+    React.ComponentPropsWithoutRef<typeof NavigationMenuPrimitives.Root>,
+    "orientation" | "defaultValue" | "dir"
+  >
+>(({ className, children, ...props }, forwardedRef) => (
+  <NavigationMenuPrimitives.Root ref={forwardedRef} {...props} asChild={false}>
+    <NavigationMenuPrimitives.List
+      className={cn(
+        // base
+        "flex items-center justify-start whitespace-nowrap border-b [scrollbar-width:none] [&::-webkit-scrollbar]:hidden",
+        // border color following design system
+        "border-border",
+        className
+      )}
+    >
+      {children}
+    </NavigationMenuPrimitives.List>
+  </NavigationMenuPrimitives.Root>
+));
+
+TabNavigation.displayName = "TabNavigation";
+
+const TabNavigationLink = React.forwardRef<
+  React.ElementRef<typeof NavigationMenuPrimitives.Link>,
+  Omit<
+    React.ComponentPropsWithoutRef<typeof NavigationMenuPrimitives.Link>,
+    "onSelect"
+  > & { disabled?: boolean; active?: boolean }
+>(
+  (
+    { asChild, disabled, active, className, children, ...props },
+    forwardedRef
+  ) => (
+    <NavigationMenuPrimitives.Item className="flex" aria-disabled={disabled}>
+      <NavigationMenuPrimitives.Link
+        aria-disabled={disabled}
+        data-active={active}
+        className={cn(
+          "group relative flex shrink-0 select-none items-center justify-center",
+          disabled ? "pointer-events-none" : ""
+        )}
+        ref={forwardedRef}
+        onSelect={() => {}}
+        asChild={asChild}
+        {...props}
+      >
+        {getSubtree({ asChild, children }, (children) => (
+          <span
+            className={cn(
+              // base - following design system spacing and typography
+              "-mb-px flex items-center justify-center whitespace-nowrap border-b-2 border-transparent px-4 py-2 text-sm font-medium transition-[color,border-color] duration-200",
+              // text color - using design system semantic tokens
+              "text-muted-foreground",
+              // hover - following design system hover patterns
+              "group-hover:text-foreground group-hover:border-border",
+              // selected - using primary color from design system
+              "group-data-[active=true]:border-primary group-data-[active=true]:text-primary",
+              // disabled - following design system disabled state
+              disabled ? "pointer-events-none text-muted-foreground/50" : "",
+              // focus - following design system focus patterns
+              "outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-2 focus-visible:ring-offset-2",
+              className
+            )}
+          >
+            {children}
+          </span>
+        ))}
+      </NavigationMenuPrimitives.Link>
+    </NavigationMenuPrimitives.Item>
+  )
+);
+
+TabNavigationLink.displayName = "TabNavigationLink";
+
+export { TabNavigation, TabNavigationLink };


### PR DESCRIPTION
## Summary
- implement financial accounts dashboard page
- add async components for accounts
- create filter bar and grid for accounts listing
- refine accounts grid and async data

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c27734b4c83308554adf1121f1041